### PR TITLE
Add ways to throttle thread creation

### DIFF
--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -64,7 +64,7 @@ impl ThreadPool {
         builder: ThreadPoolBuilder<S>,
     ) -> Result<ThreadPool, ThreadPoolBuildError>
     where
-        S: ThreadSpawn,
+        S: ThreadSpawn + Send + 'static,
     {
         let registry = Registry::new(builder)?;
         Ok(ThreadPool { registry })


### PR DESCRIPTION
This changes thread spawning to only spawn a single thread at a time. The `thread_wait_time` method allows you to specify a wait time before adding a thread to the pool which also delays spawning the next thread. The thread pool can now terminate before all worker threads have spawned. A `set_thread_target` method is added which allows you to tell the thread pool how many threads it should spawn. This thread target can change over time, but the thread pool will never remove threads once they are spawned.

To test this I used a crate which depends on 101 dummy crates each with 16 empty functions. In rustc I used `set_thread_target(16)` before creating `TyCtxt` and `set_thread_target(1)` after encoding metadata, which corresponds to the parts of rustc that takes advantage of the thread pool. `thread_wait_time` was used in rustc like this:
```rust
thread_wait_time(|index| {
    // Throttle thread creation to avoid grabbing all jobserver tokens from competing
    // rustc instances and to avoid creating many threads on smaller crates.
    if index == 0 { None } else { Some(Duration::from_millis(20 / index as u64)) }
})
```

I then compiled this crate with `-Z threads=16` and `-Z threads=1` with a parallel compiler to measure the overhead caused by spawning more threads. On Windows this was measured to 5% before this PR and 0.2% after. In a Linux VM I measured 85% overhead before this PR and 12% after. Most of the Linux improvement is likely due to reducing the thundering herd problem when the jobserver gives out a token, since less threads will be waiting on tokens.

cc @cuviper @Mark-Simulacrum @alexcrichton  
