### PR TITLE
Add  bounds for WorkerLocal's Send and Sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustc-rayon"
 # Reminder to update html_rool_url in lib.rs when updating version
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Niko Matsakis <niko@alum.mit.edu>",
            "Josh Stone <cuviper@gmail.com>"]
 description = "Simple work-stealing parallelism for Rust - fork for rustc"

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc-rayon-core"
-version = "0.3.0" # reminder to update html_root_url attribute
+version = "0.3.1" # reminder to update html_root_url attribute
 authors = ["Niko Matsakis <niko@alum.mit.edu>",
            "Josh Stone <cuviper@gmail.com>"]
 description = "Core APIs for Rayon - fork for rustc"

--- a/rayon-core/src/worker_local.rs
+++ b/rayon-core/src/worker_local.rs
@@ -15,8 +15,10 @@ pub struct WorkerLocal<T> {
     registry: Arc<Registry>,
 }
 
-unsafe impl<T> Send for WorkerLocal<T> {}
-unsafe impl<T> Sync for WorkerLocal<T> {}
+/// We prevent concurrent access to the underlying value in the
+/// Deref impl, thus any values safe to send across threads can
+/// be used with WorkerLocal.
+unsafe impl<T: Send> Sync for WorkerLocal<T> {}
 
 impl<T> WorkerLocal<T> {
     /// Creates a new worker local where the `initial` closure computes the
@@ -60,7 +62,9 @@ impl<T> WorkerLocal<Vec<T>> {
 
 impl<T: fmt::Debug> fmt::Debug for WorkerLocal<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&self.locals, f)
+        f.debug_struct("WorkerLocal")
+            .field("registry", &self.registry.id())
+            .finish()
     }
 }
 


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/81425

We could let the auto impl take care of `Send` if that would be preferable.