### PR TITLE
Update crossbeam and release 0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustc-rayon"
 # Reminder to update html_rool_url in lib.rs when updating version
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Niko Matsakis <niko@alum.mit.edu>",
            "Josh Stone <cuviper@gmail.com>"]
 description = "Simple work-stealing parallelism for Rust - fork for rustc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["ci"]
 
 [dependencies]
 rayon-core = { version = "0.3", path = "rayon-core", package = "rustc-rayon-core" }
-crossbeam-deque = "0.7.2"
+crossbeam-deque = "0.8.0"
 
 # This is a public dependency!
 [dependencies.either]

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc-rayon-core"
-version = "0.3.1" # reminder to update html_root_url attribute
+version = "0.3.2" # reminder to update html_root_url attribute
 authors = ["Niko Matsakis <niko@alum.mit.edu>",
            "Josh Stone <cuviper@gmail.com>"]
 description = "Core APIs for Rayon - fork for rustc"

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -17,8 +17,8 @@ categories = ["concurrency"]
 [dependencies]
 num_cpus = "1.2"
 lazy_static = "1"
-crossbeam-deque = "0.7.2"
-crossbeam-utils = "0.7"
+crossbeam-deque = "0.8.0"
+crossbeam-utils = "0.8.0"
 
 [dev-dependencies]
 rand = "0.7"

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -18,7 +18,6 @@ categories = ["concurrency"]
 num_cpus = "1.2"
 lazy_static = "1"
 crossbeam-deque = "0.7.2"
-crossbeam-queue = "0.2"
 crossbeam-utils = "0.7"
 
 [dev-dependencies]


### PR DESCRIPTION
This cherry-picks two updates from rayon-rs/rayon:

- c7d963a9c242 Use crossbeam_deque::Injector instead of crossbeam_queue::SegQueue
- e81835c0741d Update crossbeam dependencies (requires Rust 1.36)

cc rust-lang/rust#92677
