### PR TITLE
Don't hold the `is_blocked` lock while calling `acquire_thread`

### DIFF
--- a/rayon-core/src/sleep/mod.rs
+++ b/rayon-core/src/sleep/mod.rs
@@ -286,6 +286,10 @@ impl Sleep {
             while *is_blocked {
                 is_blocked = sleep_state.condvar.wait(is_blocked).unwrap();
             }
+
+            // Drop `is_blocked` now in case `acquire_thread` blocks
+            drop(is_blocked);
+
             registry.acquire_thread();
         }
 


### PR DESCRIPTION
This fixes a deadlock since `acquire_thread` ends up blocking on a jobserver token in `rustc`.