### PR TITLE
Only work-steal in the main loop

### DIFF
--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -20,6 +20,7 @@ name = "rayon_core"
 [dependencies]
 crossbeam-deque = "0.8.1"
 crossbeam-utils = "0.8.0"
+smallvec = "1.11.0"
 
 [dev-dependencies]
 rand = "0.9"

--- a/rayon-core/src/broadcast/mod.rs
+++ b/rayon-core/src/broadcast/mod.rs
@@ -3,6 +3,7 @@ use crate::latch::{CountLatch, LatchRef};
 use crate::registry::{Registry, WorkerThread};
 use std::fmt;
 use std::marker::PhantomData;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 mod test;
@@ -99,13 +100,22 @@ where
     OP: Fn(BroadcastContext<'_>) -> R + Sync,
     R: Send,
 {
+    let current_thread = WorkerThread::current();
+    let current_thread_addr = current_thread as usize;
+    let started = &AtomicBool::new(false);
     let f = move |injected: bool| {
         debug_assert!(injected);
+
+        // Mark as started if we are on the thread that initiated the broadcast.
+        if current_thread_addr == WorkerThread::current() as usize {
+            started.store(true, Ordering::Relaxed);
+        }
+
         BroadcastContext::with(&op)
     };
 
     let n_threads = registry.num_threads();
-    let current_thread = WorkerThread::current().as_ref();
+    let current_thread = current_thread.as_ref();
     let tlv = crate::tlv::get();
     let latch = CountLatch::with_count(n_threads, current_thread);
     let jobs: Vec<_> = (0..n_threads)
@@ -115,8 +125,16 @@ where
 
     registry.inject_broadcast(job_refs);
 
+    let current_thread_job_id = current_thread
+        .and_then(|worker| (registry.id() == worker.registry.id()).then(|| worker))
+        .map(|worker| jobs[worker.index].as_job_ref().id());
+
     // Wait for all jobs to complete, then collect the results, maybe propagating a panic.
-    latch.wait(current_thread);
+    latch.wait(
+        current_thread,
+        || started.load(Ordering::Relaxed),
+        |job| Some(job.id()) == current_thread_job_id,
+    );
     jobs.into_iter().map(|job| job.into_result()).collect()
 }
 
@@ -132,7 +150,7 @@ where
 {
     let job = ArcJob::new({
         let registry = Arc::clone(registry);
-        move || {
+        move |_| {
             registry.catch_unwind(|| BroadcastContext::with(&op));
             registry.terminate(); // (*) permit registry to terminate now
         }

--- a/rayon-core/src/broadcast/test.rs
+++ b/rayon-core/src/broadcast/test.rs
@@ -64,6 +64,7 @@ fn spawn_broadcast_self() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn broadcast_mutual() {
     let count = AtomicUsize::new(0);
@@ -98,6 +99,7 @@ fn spawn_broadcast_mutual() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn broadcast_mutual_sleepy() {
     let count = AtomicUsize::new(0);

--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -1,9 +1,10 @@
+use crate::job::JobRef;
 use crate::job::StackJob;
 use crate::latch::SpinLatch;
-use crate::registry::{self, WorkerThread};
-use crate::tlv::{self, Tlv};
+use crate::registry;
+use crate::tlv;
 use crate::unwind;
-use std::any::Any;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::FnContext;
 
@@ -135,68 +136,41 @@ where
         // Create virtual wrapper for task b; this all has to be
         // done here so that the stack frame can keep it all live
         // long enough.
-        let job_b = StackJob::new(tlv, call_b(oper_b), SpinLatch::new(worker_thread));
+        let job_b_started = AtomicBool::new(false);
+        let job_b = StackJob::new(
+            tlv,
+            |migrated| {
+                job_b_started.store(true, Ordering::Relaxed);
+                call_b(oper_b)(migrated)
+            },
+            SpinLatch::new(worker_thread),
+        );
         let job_b_ref = job_b.as_job_ref();
         let job_b_id = job_b_ref.id();
         worker_thread.push(job_b_ref);
 
         // Execute task a; hopefully b gets stolen in the meantime.
         let status_a = unwind::halt_unwinding(call_a(oper_a, injected));
-        let result_a = match status_a {
-            Ok(v) => v,
-            Err(err) => join_recover_from_panic(worker_thread, &job_b.latch, err, tlv),
-        };
 
-        // Now that task A has finished, try to pop job B from the
-        // local stack.  It may already have been popped by job A; it
-        // may also have been stolen. There may also be some tasks
-        // pushed on top of it in the stack, and we will have to pop
-        // those off to get to it.
-        while !job_b.latch.probe() {
-            if let Some(job) = worker_thread.take_local_job() {
-                if job_b_id == job.id() {
-                    // Found it! Let's run it.
-                    //
-                    // Note that this could panic, but it's ok if we unwind here.
-
-                    // Restore the TLV since we might have run some jobs overwriting it when waiting for job b.
-                    tlv::set(tlv);
-
-                    let result_b = job_b.run_inline(injected);
-                    return (result_a, result_b);
-                } else {
-                    worker_thread.execute(job);
-                }
-            } else {
-                // Local deque is empty. Time to steal from other
-                // threads.
-                worker_thread.wait_until(&job_b.latch);
-                debug_assert!(job_b.latch.probe());
-                break;
-            }
-        }
+        // Wait for job B or execute it if it's in the local queue.
+        worker_thread.wait_for_jobs::<_, false>(
+            &job_b.latch,
+            || job_b_started.load(Ordering::Relaxed),
+            |job| job.id() == job_b_id,
+            |job: JobRef| {
+                debug_assert_eq!(job.id(), job_b_id);
+                job_b.run_inline(injected);
+            },
+        );
 
         // Restore the TLV since we might have run some jobs overwriting it when waiting for job b.
         tlv::set(tlv);
 
+        let result_a = match status_a {
+            Ok(v) => v,
+            Err(err) => unwind::resume_unwinding(err),
+        };
+
         (result_a, job_b.into_result())
     })
-}
-
-/// If job A panics, we still cannot return until we are sure that job
-/// B is complete. This is because it may contain references into the
-/// enclosing stack frame(s).
-#[cold] // cold path
-unsafe fn join_recover_from_panic(
-    worker_thread: &WorkerThread,
-    job_b_latch: &SpinLatch<'_>,
-    err: Box<dyn Any + Send>,
-    tlv: Tlv,
-) -> ! {
-    worker_thread.wait_until(job_b_latch);
-
-    // Restore the TLV since we might have run some jobs overwriting it when waiting for job b.
-    tlv::set(tlv);
-
-    unwind::resume_unwinding(err)
 }

--- a/rayon-core/src/join/test.rs
+++ b/rayon-core/src/join/test.rs
@@ -96,6 +96,7 @@ fn join_context_both() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn join_context_neither() {
     // If we're already in a 1-thread pool, neither job should be stolen.

--- a/rayon-core/src/latch.rs
+++ b/rayon-core/src/latch.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 
+use crate::job::JobRef;
 use crate::registry::{Registry, WorkerThread};
 
 /// We define various kinds of latches, which are all a primitive signaling
@@ -175,11 +176,6 @@ impl<'r> SpinLatch<'r> {
             cross: true,
             ..SpinLatch::new(thread)
         }
-    }
-
-    #[inline]
-    pub(super) fn probe(&self) -> bool {
-        self.core_latch.probe()
     }
 }
 
@@ -385,7 +381,12 @@ impl CountLatch {
         debug_assert!(old_counter != 0);
     }
 
-    pub(super) fn wait(&self, owner: Option<&WorkerThread>) {
+    pub(super) fn wait(
+        &self,
+        owner: Option<&WorkerThread>,
+        all_jobs_started: impl FnMut() -> bool,
+        is_job: impl FnMut(&JobRef) -> bool,
+    ) {
         match &self.kind {
             CountLatchKind::Stealing {
                 latch,
@@ -395,7 +396,9 @@ impl CountLatch {
                 let owner = owner.expect("owner thread");
                 debug_assert_eq!(registry.id(), owner.registry().id());
                 debug_assert_eq!(*worker_index, owner.index());
-                owner.wait_until(latch);
+                owner.wait_for_jobs::<_, true>(latch, all_jobs_started, is_job, |job| {
+                    owner.execute(job)
+                });
             },
             CountLatchKind::Blocking { latch } => latch.wait(),
         }

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -8,6 +8,7 @@ use crate::{
     ReleaseThreadHandler, StartHandler, ThreadPoolBuildError, ThreadPoolBuilder, Yield,
 };
 use crossbeam_deque::{Injector, Steal, Stealer, Worker};
+use smallvec::SmallVec;
 use std::cell::Cell;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt;
@@ -813,14 +814,87 @@ impl WorkerThread {
     /// stealing tasks as necessary.
     #[inline]
     pub(super) unsafe fn wait_until<L: AsCoreLatch + ?Sized>(&self, latch: &L) {
+        self.wait_or_steal_until(latch, false)
+    }
+
+    /// Wait until the latch is set. Executes local jobs if `is_job` is true for them and
+    /// `all_jobs_started` still returns false.
+    #[inline]
+    pub(super) unsafe fn wait_for_jobs<L: AsCoreLatch + ?Sized, const BROADCAST_JOBS: bool>(
+        &self,
+        latch: &L,
+        mut all_jobs_started: impl FnMut() -> bool,
+        mut is_job: impl FnMut(&JobRef) -> bool,
+        mut execute_job: impl FnMut(JobRef),
+    ) {
+        let mut jobs = SmallVec::<[JobRef; 8]>::new();
+        let mut broadcast_jobs = SmallVec::<[JobRef; 8]>::new();
+
+        // Make sure all jobs have started.
+        while !all_jobs_started() {
+            if let Some(job) = self.worker.pop() {
+                if is_job(&job) {
+                    // Found a job, let's run it.
+                    execute_job(job);
+                } else {
+                    jobs.push(job);
+                }
+            } else {
+                if BROADCAST_JOBS {
+                    let broadcast_job = loop {
+                        match self.stealer.steal() {
+                            Steal::Success(job) => break Some(job),
+                            Steal::Empty => break None,
+                            Steal::Retry => {}
+                        }
+                    };
+                    if let Some(job) = broadcast_job {
+                        if is_job(&job) {
+                            // Found a job, let's run it.
+                            self.execute(job);
+                        } else {
+                            broadcast_jobs.push(job);
+                        }
+                    }
+                }
+                break;
+            }
+        }
+
+        // Restore the jobs that we weren't looking for.
+        for job in jobs.into_iter().rev() {
+            self.worker.push(job);
+        }
+        if BROADCAST_JOBS {
+            let broadcasts = self.registry.broadcasts.lock().unwrap();
+            for job in broadcast_jobs.into_iter() {
+                broadcasts[self.index].push(job);
+            }
+        }
+
+        // Wait for the jobs to finish.
+        self.wait_until(latch);
+        debug_assert!(latch.as_core_latch().probe());
+    }
+
+    #[inline]
+    pub(super) unsafe fn wait_or_steal_until<L: AsCoreLatch + ?Sized>(
+        &self,
+        latch: &L,
+        steal: bool,
+    ) {
         let latch = latch.as_core_latch();
         if !latch.probe() {
-            self.wait_until_cold(latch);
+            if steal {
+                self.wait_or_steal_until_cold(latch);
+            } else {
+                self.wait_until_cold(latch);
+            }
         }
     }
 
     #[cold]
-    unsafe fn wait_until_cold(&self, latch: &CoreLatch) {
+    unsafe fn wait_or_steal_until_cold(&self, latch: &CoreLatch) {
         // the code below should swallow all panics and hence never
         // unwind; but if something does wrong, we want to abort,
         // because otherwise other code in rayon may assume that the
@@ -846,7 +920,7 @@ impl WorkerThread {
                 } else {
                     self.registry
                         .sleep
-                        .no_work_found(&mut idle_state, latch, &self)
+                        .no_work_found(&mut idle_state, latch, &self, true)
                 }
             }
 
@@ -859,13 +933,36 @@ impl WorkerThread {
         mem::forget(abort_guard); // successful execution, do not abort
     }
 
+    #[cold]
+    unsafe fn wait_until_cold(&self, latch: &CoreLatch) {
+        // the code below should swallow all panics and hence never
+        // unwind; but if something does wrong, we want to abort,
+        // because otherwise other code in rayon may assume that the
+        // latch has been signaled, and that can lead to random memory
+        // accesses, which would be *very bad*
+        let abort_guard = unwind::AbortIfPanic;
+
+        let mut idle_state = self.registry.sleep.start_looking(self.index);
+        while !latch.probe() {
+            self.registry
+                .sleep
+                .no_work_found(&mut idle_state, latch, &self, false)
+        }
+
+        // If we were sleepy, we are not anymore. We "found work" --
+        // whatever the surrounding thread was doing before it had to wait.
+        self.registry.sleep.work_found();
+
+        mem::forget(abort_guard); // successful execution, do not abort
+    }
+
     unsafe fn wait_until_out_of_work(&self) {
         debug_assert_eq!(self as *const _, WorkerThread::current());
         let registry = &*self.registry;
         let index = self.index;
 
         registry.acquire_thread();
-        self.wait_until(&registry.thread_infos[index].terminate);
+        self.wait_or_steal_until(&registry.thread_infos[index].terminate, true);
 
         // Should not be any work left in our queue.
         debug_assert!(self.take_local_job().is_none());

--- a/rayon-core/src/scope/mod.rs
+++ b/rayon-core/src/scope/mod.rs
@@ -6,18 +6,19 @@
 //! [`join()`]: ../join/join.fn.html
 
 use crate::broadcast::BroadcastContext;
-use crate::job::{ArcJob, HeapJob, JobFifo, JobRef};
+use crate::job::{ArcJob, HeapJob, JobFifo, JobRef, JobRefId};
 use crate::latch::{CountLatch, Latch};
 use crate::registry::{global_registry, in_worker, Registry, WorkerThread};
 use crate::tlv::{self, Tlv};
 use crate::unwind;
 use std::any::Any;
+use std::collections::HashSet;
 use std::fmt;
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::ptr;
 use std::sync::atomic::{AtomicPtr, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 #[cfg(test)]
 mod test;
@@ -40,7 +41,7 @@ pub struct ScopeFifo<'scope> {
     fifos: Vec<JobFifo>,
 }
 
-struct ScopeBase<'scope> {
+pub(super) struct ScopeBase<'scope> {
     /// thread registry where `scope()` was executed or where `in_place_scope()`
     /// should spawn jobs.
     registry: Arc<Registry>,
@@ -51,6 +52,12 @@ struct ScopeBase<'scope> {
 
     /// latch to track job counts
     job_completed_latch: CountLatch,
+
+    /// Jobs that have been spawned, but not yet started.
+    pending_jobs: Mutex<HashSet<JobRefId>>,
+
+    /// The worker which will wait on scope completion, if any.
+    worker: Option<usize>,
 
     /// You can think of a scope as containing a list of closures to execute,
     /// all of which outlive `'scope`.  They're not actually required to be
@@ -525,12 +532,19 @@ impl<'scope> Scope<'scope> {
         BODY: FnOnce(&Scope<'scope>) + Send + 'scope,
     {
         let scope_ptr = ScopePtr(self);
-        let job = HeapJob::new(self.base.tlv, move || unsafe {
+        let job = HeapJob::new(self.base.tlv, move |id| unsafe {
             // SAFETY: this job will execute before the scope ends.
             let scope = scope_ptr.as_ref();
+
+            // Mark this job as started.
+            scope.base.pending_jobs.lock().unwrap().remove(&id);
+
             ScopeBase::execute_job(&scope.base, move || body(scope))
         });
         let job_ref = self.base.heap_job_ref(job);
+
+        // Mark this job as pending.
+        self.base.pending_jobs.lock().unwrap().insert(job_ref.id());
 
         // Since `Scope` implements `Sync`, we can't be sure that we're still in a
         // thread of this pool, so we can't just push to the local worker thread.
@@ -547,13 +561,21 @@ impl<'scope> Scope<'scope> {
         BODY: Fn(&Scope<'scope>, BroadcastContext<'_>) + Send + Sync + 'scope,
     {
         let scope_ptr = ScopePtr(self);
-        let job = ArcJob::new(move || unsafe {
+        let job = ArcJob::new(move |id| unsafe {
             // SAFETY: this job will execute before the scope ends.
             let scope = scope_ptr.as_ref();
             let body = &body;
+
+            let current_index = WorkerThread::current().as_ref().map(|worker| worker.index);
+            if current_index == scope.base.worker {
+                // Mark this job as started on the scope's worker thread
+                scope.base.pending_jobs.lock().unwrap().remove(&id);
+            }
+
             let func = move || BroadcastContext::with(move |ctx| body(scope, ctx));
             ScopeBase::execute_job(&scope.base, func)
         });
+
         self.base.inject_broadcast(job)
     }
 }
@@ -585,23 +607,24 @@ impl<'scope> ScopeFifo<'scope> {
         BODY: FnOnce(&ScopeFifo<'scope>) + Send + 'scope,
     {
         let scope_ptr = ScopePtr(self);
-        let job = HeapJob::new(self.base.tlv, move || unsafe {
+        let job = HeapJob::new(self.base.tlv, move |id| unsafe {
             // SAFETY: this job will execute before the scope ends.
             let scope = scope_ptr.as_ref();
+
+            // Mark this job as started.
+            scope.base.pending_jobs.lock().unwrap().remove(&id);
+
             ScopeBase::execute_job(&scope.base, move || body(scope))
         });
         let job_ref = self.base.heap_job_ref(job);
 
-        // If we're in the pool, use our scope's private fifo for this thread to execute
-        // in a locally-FIFO order. Otherwise, just use the pool's global injector.
-        match self.base.registry.current_thread() {
-            Some(worker) => {
-                let fifo = &self.fifos[worker.index()];
-                // SAFETY: this job will execute before the scope ends.
-                unsafe { worker.push(fifo.push(job_ref)) };
-            }
-            None => self.base.registry.inject(job_ref),
-        }
+        // Mark this job as pending.
+        self.base.pending_jobs.lock().unwrap().insert(job_ref.id());
+
+        // Since `Scope` implements `Sync`, we can't be sure that we're still in a
+        // thread of this pool, so we can't just push to the local worker thread.
+        // Also, this might be an in-place scope.
+        self.base.registry.inject_or_push(job_ref);
     }
 
     /// Spawns a job into every thread of the fork-join scope `self`. This job will
@@ -613,13 +636,21 @@ impl<'scope> ScopeFifo<'scope> {
         BODY: Fn(&ScopeFifo<'scope>, BroadcastContext<'_>) + Send + Sync + 'scope,
     {
         let scope_ptr = ScopePtr(self);
-        let job = ArcJob::new(move || unsafe {
+        let job = ArcJob::new(move |id| unsafe {
             // SAFETY: this job will execute before the scope ends.
             let scope = scope_ptr.as_ref();
             let body = &body;
+
+            let current_index = WorkerThread::current().as_ref().map(|worker| worker.index);
+            if current_index == scope.base.worker {
+                // Mark this job as started on the scope's worker thread
+                scope.base.pending_jobs.lock().unwrap().remove(&id);
+            }
+
             let func = move || BroadcastContext::with(move |ctx| body(scope, ctx));
             ScopeBase::execute_job(&scope.base, func)
         });
+
         self.base.inject_broadcast(job)
     }
 }
@@ -636,14 +667,16 @@ impl<'scope> ScopeBase<'scope> {
             registry: Arc::clone(registry),
             panic: AtomicPtr::new(ptr::null_mut()),
             job_completed_latch: CountLatch::new(owner),
+            pending_jobs: Mutex::new(HashSet::new()),
             marker: PhantomData,
+            worker: owner.map(|owner| owner.index),
             tlv: tlv::get(),
         }
     }
 
     fn heap_job_ref<FUNC>(&self, job: Box<HeapJob<FUNC>>) -> JobRef
     where
-        FUNC: FnOnce() + Send + 'scope,
+        FUNC: FnOnce(JobRefId) + Send + 'scope,
     {
         unsafe {
             self.job_completed_latch.increment();
@@ -651,10 +684,22 @@ impl<'scope> ScopeBase<'scope> {
         }
     }
 
-    fn inject_broadcast<FUNC>(&self, job: Arc<ArcJob<FUNC>>)
+    fn inject_broadcast<FUNC>(&self, mut job: Arc<ArcJob<FUNC>>)
     where
-        FUNC: Fn() + Send + Sync + 'scope,
+        FUNC: Fn(JobRefId) + Send + Sync + 'scope,
     {
+        if self.worker.is_some() {
+            unsafe {
+                // Get an id of the job
+                let raw = Arc::into_raw(job);
+                let id = JobRef::new(raw).id();
+                job = Arc::from_raw(raw);
+
+                // Mark this job as pending.
+                self.pending_jobs.lock().unwrap().insert(id);
+            }
+        }
+
         let n_threads = self.registry.num_threads();
         let job_refs = (0..n_threads).map(|_| unsafe {
             self.job_completed_latch.increment();
@@ -671,7 +716,11 @@ impl<'scope> ScopeBase<'scope> {
         FUNC: FnOnce() -> R,
     {
         let result = unsafe { Self::execute_job_closure(self, func) };
-        self.job_completed_latch.wait(owner);
+        self.job_completed_latch.wait(
+            owner,
+            || self.pending_jobs.lock().unwrap().is_empty(),
+            |job| self.pending_jobs.lock().unwrap().contains(&job.id()),
+        );
 
         // Restore the TLV if we ran some jobs while waiting
         tlv::set(self.tlv);

--- a/rayon-core/src/scope/test.rs
+++ b/rayon-core/src/scope/test.rs
@@ -300,6 +300,7 @@ macro_rules! test_order {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn lifo_order() {
     // In the absence of stealing, `scope()` runs its `spawn()` jobs in LIFO order.
@@ -309,6 +310,7 @@ fn lifo_order() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn fifo_order() {
     // In the absence of stealing, `scope_fifo()` runs its `spawn_fifo()` jobs in FIFO order.
@@ -344,6 +346,7 @@ macro_rules! test_nested_order {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn nested_lifo_order() {
     // In the absence of stealing, `scope()` runs its `spawn()` jobs in LIFO order.
@@ -353,6 +356,7 @@ fn nested_lifo_order() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn nested_fifo_order() {
     // In the absence of stealing, `scope_fifo()` runs its `spawn_fifo()` jobs in FIFO order.
@@ -362,6 +366,7 @@ fn nested_fifo_order() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn nested_lifo_fifo_order() {
     // LIFO on the outside, FIFO on the inside
@@ -374,6 +379,7 @@ fn nested_lifo_fifo_order() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn nested_fifo_lifo_order() {
     // FIFO on the outside, LIFO on the inside
@@ -417,6 +423,7 @@ macro_rules! test_mixed_order {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn mixed_lifo_order() {
     // NB: the end of the inner scope makes us execute some of the outer scope
@@ -427,6 +434,7 @@ fn mixed_lifo_order() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn mixed_fifo_order() {
     let vec = test_mixed_order!(scope_fifo => spawn_fifo, scope_fifo => spawn_fifo);
@@ -435,6 +443,7 @@ fn mixed_fifo_order() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn mixed_lifo_fifo_order() {
     // NB: the end of the inner scope makes us execute some of the outer scope
@@ -445,6 +454,7 @@ fn mixed_lifo_fifo_order() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn mixed_fifo_lifo_order() {
     let vec = test_mixed_order!(scope_fifo => spawn_fifo, scope => spawn);
@@ -534,8 +544,9 @@ fn mixed_lifetime_scope_fifo() {
 
 #[test]
 fn scope_spawn_broadcast() {
+    let pool = ThreadPoolBuilder::new().num_threads(7).build().unwrap();
     let sum = AtomicUsize::new(0);
-    let n = scope(|s| {
+    let n = pool.scope(|s| {
         s.spawn_broadcast(|_, ctx| {
             sum.fetch_add(ctx.index(), Ordering::Relaxed);
         });
@@ -546,8 +557,9 @@ fn scope_spawn_broadcast() {
 
 #[test]
 fn scope_fifo_spawn_broadcast() {
+    let pool = ThreadPoolBuilder::new().num_threads(7).build().unwrap();
     let sum = AtomicUsize::new(0);
-    let n = scope_fifo(|s| {
+    let n = pool.scope_fifo(|s| {
         s.spawn_broadcast(|_, ctx| {
             sum.fetch_add(ctx.index(), Ordering::Relaxed);
         });
@@ -557,6 +569,7 @@ fn scope_fifo_spawn_broadcast() {
 }
 
 #[test]
+#[ignore]
 fn scope_spawn_broadcast_nested() {
     let sum = AtomicUsize::new(0);
     let n = scope(|s| {

--- a/rayon-core/src/sleep/mod.rs
+++ b/rayon-core/src/sleep/mod.rs
@@ -146,6 +146,7 @@ impl Sleep {
         idle_state: &mut IdleState,
         latch: &CoreLatch,
         thread: &WorkerThread,
+        steal: bool,
     ) {
         if idle_state.rounds < ROUNDS_UNTIL_SLEEPY {
             thread::yield_now();
@@ -159,7 +160,7 @@ impl Sleep {
             thread::yield_now();
         } else {
             debug_assert_eq!(idle_state.rounds, ROUNDS_UNTIL_SLEEPING);
-            self.sleep(idle_state, latch, thread);
+            self.sleep(idle_state, latch, thread, steal);
         }
     }
 
@@ -171,7 +172,13 @@ impl Sleep {
     }
 
     #[cold]
-    fn sleep(&self, idle_state: &mut IdleState, latch: &CoreLatch, thread: &WorkerThread) {
+    fn sleep(
+        &self,
+        idle_state: &mut IdleState,
+        latch: &CoreLatch,
+        thread: &WorkerThread,
+        steal: bool,
+    ) {
         let worker_index = idle_state.worker_index;
 
         if !latch.get_sleepy() {
@@ -219,7 +226,7 @@ impl Sleep {
         // - that job triggers the rollover over the JEC such that we don't see it
         // - we are the last active worker thread
         std::sync::atomic::fence(Ordering::SeqCst);
-        if thread.has_injected_job() {
+        if steal && thread.has_injected_job() {
             // If we see an externally injected job, then we have to 'wake
             // ourselves up'. (Ordinarily, `sub_sleeping_thread` is invoked by
             // the one that wakes us.)

--- a/rayon-core/src/spawn/mod.rs
+++ b/rayon-core/src/spawn/mod.rs
@@ -94,7 +94,7 @@ where
 
     HeapJob::new(Tlv::null(), {
         let registry = Arc::clone(registry);
-        move || {
+        move |_| {
             registry.catch_unwind(func);
             registry.terminate(); // (*) permit registry to terminate now
         }

--- a/rayon-core/src/spawn/test.rs
+++ b/rayon-core/src/spawn/test.rs
@@ -171,6 +171,7 @@ macro_rules! test_order {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn lifo_order() {
     // In the absence of stealing, `spawn()` jobs on a thread will run in LIFO order.
@@ -180,6 +181,7 @@ fn lifo_order() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn fifo_order() {
     // In the absence of stealing, `spawn_fifo()` jobs on a thread will run in FIFO order.
@@ -189,6 +191,7 @@ fn fifo_order() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn lifo_fifo_order() {
     // LIFO on the outside, FIFO on the inside
@@ -201,6 +204,7 @@ fn lifo_fifo_order() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn fifo_lifo_order() {
     // FIFO on the outside, LIFO on the inside
@@ -239,6 +243,7 @@ macro_rules! test_mixed_order {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn mixed_lifo_fifo_order() {
     let vec = test_mixed_order!(spawn, spawn_fifo);
@@ -247,6 +252,7 @@ fn mixed_lifo_fifo_order() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn mixed_fifo_lifo_order() {
     let vec = test_mixed_order!(spawn_fifo, spawn);

--- a/rayon-core/src/thread_pool/test.rs
+++ b/rayon-core/src/thread_pool/test.rs
@@ -152,6 +152,7 @@ fn self_install() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn mutual_install() {
     let pool1 = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
@@ -172,6 +173,7 @@ fn mutual_install() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn mutual_install_sleepy() {
     use std::{thread, time};
@@ -235,6 +237,7 @@ fn scope_lifo_order() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn scope_fifo_order() {
     let vec = test_scope_order!(scope_fifo => spawn_fifo);
@@ -276,6 +279,7 @@ fn spawn_fifo_order() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn nested_scopes() {
     // Create matching scopes for every thread pool.
@@ -313,6 +317,7 @@ fn nested_scopes() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn nested_fifo_scopes() {
     // Create matching fifo scopes for every thread pool.

--- a/rayon-core/tests/stack_overflow_crash.rs
+++ b/rayon-core/tests/stack_overflow_crash.rs
@@ -41,7 +41,7 @@ fn overflow_code() -> Option<i32> {
 }
 
 #[test]
-#[cfg_attr(not(any(unix, windows)), ignore)]
+#[cfg_attr(not(any(unix)), ignore)]
 fn stack_overflow_crash() {
     // First check that the recursive call actually causes a stack overflow,
     // and does not get optimized away.

--- a/src/range.rs
+++ b/src/range.rs
@@ -429,6 +429,7 @@ fn test_u128_opt_len() {
 // when using the `opt_len` "indexed" mode.
 #[test]
 #[cfg(target_pointer_width = "64")]
+#[ignore]
 fn test_usize_i64_overflow() {
     use crate::ThreadPoolBuilder;
     use std::i64;

--- a/src/range_inclusive.rs
+++ b/src/range_inclusive.rs
@@ -353,6 +353,7 @@ fn test_u128_opt_len() {
 // when using the `opt_len` "indexed" mode.
 #[test]
 #[cfg(target_pointer_width = "64")]
+#[ignore]
 fn test_usize_i64_overflow() {
     use crate::ThreadPoolBuilder;
     use std::i64;

--- a/tests/octillion.rs
+++ b/tests/octillion.rs
@@ -68,6 +68,7 @@ fn two_threads<F: Send + FnOnce() -> R, R: Send>(f: F) -> R {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(
     any(
         not(target_pointer_width = "64"),
@@ -85,6 +86,7 @@ fn find_last_octillion() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(
     any(
         not(target_pointer_width = "64"),
@@ -99,6 +101,7 @@ fn find_last_octillion_inclusive() {
 }
 
 #[test]
+#[ignore]
 #[cfg_attr(
     any(
         not(target_pointer_width = "64"),


### PR DESCRIPTION
This PR removes work stealing from other threads, except when in the main loop. This avoids situations where we steal work we can't complete due to waiting on queries. This should fix bugs like https://github.com/rust-lang/rust/issues/111521 and https://github.com/rust-lang/rust/issues/115223, but it does have a negative performance impact.

Tests for 6 threads:
<table><tr><td rowspan="2">Benchmark</td><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th></tr><tr><td align="right">Time</td><td align="right">Time</td><td align="right">%</th></tr><tr><td>🟣 <b>clap</b>:check</td><td align="right">0.6502s</td><td align="right">0.7641s</td><td align="right">💔  17.52%</td></tr><tr><td>🟣 <b>hyper</b>:check</td><td align="right">0.1396s</td><td align="right">0.1508s</td><td align="right">💔  8.00%</td></tr><tr><td>🟣 <b>regex</b>:check</td><td align="right">0.4033s</td><td align="right">0.4413s</td><td align="right">💔  9.43%</td></tr><tr><td>🟣 <b>syn</b>:check</td><td align="right">0.6749s</td><td align="right">0.7749s</td><td align="right">💔  14.81%</td></tr><tr><td>🟣 <b>syntex_syntax</b>:check</td><td align="right">2.1708s</td><td align="right">2.4696s</td><td align="right">💔  13.76%</td></tr><tr><td>Total</td><td align="right">4.0389s</td><td align="right">4.6007s</td><td align="right">💔  13.91%</td></tr><tr><td>Summary</td><td align="right">1.0000s</td><td align="right">1.1270s</td><td align="right">💔  12.70%</td></tr></table>
<table><tr><td rowspan="2">Benchmark</td><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th></tr><tr><td align="right">Time</td><td align="right">Time</td><td align="right">%</th></tr><tr><td>🟠 <b>clap</b>:debug</td><td align="right">2.3400s</td><td align="right">2.4645s</td><td align="right">💔  5.32%</td></tr><tr><td>🟠 <b>hyper</b>:debug</td><td align="right">0.3807s</td><td align="right">0.3919s</td><td align="right">💔  2.96%</td></tr><tr><td>🟠 <b>regex</b>:debug</td><td align="right">1.7557s</td><td align="right">1.7719s</td><td align="right"> 0.92%</td></tr><tr><td>🟠 <b>syn</b>:debug</td><td align="right">1.7401s</td><td align="right">1.8426s</td><td align="right">💔  5.89%</td></tr><tr><td>🟠 <b>syntex_syntax</b>:debug</td><td align="right">6.6743s</td><td align="right">6.9144s</td><td align="right">💔  3.60%</td></tr><tr><td>Total</td><td align="right">12.8908s</td><td align="right">13.3854s</td><td align="right">💔  3.84%</td></tr><tr><td>Summary</td><td align="right">1.0000s</td><td align="right">1.0374s</td><td align="right">💔  3.74%</td></tr></table>
